### PR TITLE
add exteded options for validation plots

### DIFF
--- a/validate
+++ b/validate
@@ -498,6 +498,7 @@ function make_validation_plots() {
       if [ "$WORKFLOW" == "$REFERENCE_WORKFLOW" ]; then
         # reference workflow
         makeTrackValidationPlots.py \
+          --extended \
           --html-sample $DATASET \
           --html-validation-name $DATASET \
           --outputDir $UPLOAD_DIR/$JOBID/$WORKDIR/$REFERENCE_WORKFLOW \


### PR DESCRIPTION
chi2 distributions and number of tracks vs pt/eta/phi distributions are shown only when using the extended option in makeTrackValidationPlots.py